### PR TITLE
docs(campus-maps-sos): add Alert-yaar24 related link

### DIFF
--- a/campus-maps-sos/README.md
+++ b/campus-maps-sos/README.md
@@ -16,3 +16,8 @@ Starter tasks
 Good first tasks
 - Add sample JSON data and a UI that lists rooms
 - Implement basic search/filter UI
+
+Related projects
+- External example: Alert-yaar24 branches — https://github.com/Ethicalmind/Alert-yaar24/branches
+
+If this link should point to a specific branch or PR, mention it in an issue or provide the exact URL and I'll update this file.


### PR DESCRIPTION
Adds a 'Related projects' link referencing https://github.com/Ethicalmind/Alert-yaar24/branches. No code copied; only a reference.